### PR TITLE
fix for issue #11834

### DIFF
--- a/packages/wdio-utils/src/shim.ts
+++ b/packages/wdio-utils/src/shim.ts
@@ -50,6 +50,12 @@ export async function executeHooksWithArgs<T> (this: any, hookName: string, hook
             if (/^(sync|async) skip; aborting execution$/.test(e.message)) {
                 return reject()
             }
+            /**
+            * in case of jasmine, when rejecting, we need to pass the message of rejection as well
+            */
+            if (/^=> marked Pending/.test(e)) {
+                return reject(e);
+            }
             log.error(e.stack)
             return resolve(e)
         }


### PR DESCRIPTION
## Proposed changes

This is a fix for issue #11834. 
This will enable skipping tests from `beforeTest` hook in config file. just like https://github.com/webdriverio/webdriverio/pull/11158 did for Mocha

the result is that the test is skipped:
![image](https://github.com/HananArgov/webdriverio/assets/48208030/ad1d645b-94f6-45b3-a019-7f39bc00e405)


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

this is an implementation based on a previous one for Mocha: (https://github.com/webdriverio/webdriverio/pull/11158)

### Reviewers: @webdriverio/project-committers
